### PR TITLE
feat: 네이버 지도 API 연동, 진단에 따른 병원 정보 화면 구현 진행중

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/java,kotlin,androidstudio
+
+# API 키
+/local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,18 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
+
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(localPropertiesFile.inputStream())
+}
+
+val naverMapClientId = localProperties.getProperty("NAVER_MAP_CLIENT_ID")
 
 android {
     namespace = "com.openstudy.carefull"
@@ -16,6 +26,8 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        manifestPlaceholders["NAVER_CLIENT_ID"] = naverMapClientId
     }
 
     buildTypes {
@@ -51,6 +63,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.navigation.runtime.android)
+    implementation("com.naver.maps:map-sdk:3.22.0")
+    implementation(libs.play.services.maps)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Carefull"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.naver.maps.map.CLIENT_ID"
+            android:value="${NAVER_CLIENT_ID}" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/openstudy/carefull/hospitalInfo/HospitalInfoScreen.kt
+++ b/app/src/main/java/com/openstudy/carefull/hospitalInfo/HospitalInfoScreen.kt
@@ -1,0 +1,93 @@
+package com.openstudy.carefull.hospitalInfo
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.MapView
+import com.openstudy.carefull.ui.theme.CarefullTheme
+
+@Composable
+fun HospitalInfoScreen() {
+
+    val context = LocalContext.current
+    val mapView = remember {
+        MapView(context).apply {
+            getMapAsync { naverMap ->
+                naverMap.cameraPosition = CameraPosition(
+                    LatLng(37.5665, 126.9780),
+                    14.0
+                )
+            }
+        }
+    }
+
+    var selectedHospitalType by remember { mutableStateOf("우수병원") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "예상 병명",
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "진료 과목",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        AndroidView(
+            factory = { mapView },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(250.dp)
+                .clip(RoundedCornerShape(12.dp))
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "병원 보기",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "선택된 병원 종류: $selectedHospitalType",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HospitalInfoScreenPreview() {
+    CarefullTheme {
+        HospitalInfoScreen()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ activityCompose = "1.10.1"
 composeBom = "2025.06.01"
 navigationCompose = "2.9.0"
 navigationRuntimeAndroid = "2.9.0"
+playServicesMaps = "19.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
+play-services-maps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "playServicesMaps" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://repository.map.naver.com/archive/maven")
     }
 }
 


### PR DESCRIPTION
## 📝 작업 내용 
- 챗봇을 통해 얻은 진단명을 토대로 사용자 중심의 병원을 보여주는 화면을 구현하고 있습니다.
- 네이버 지도를 사용하였습니다.
- API 키는 local.properties 파일을 따로 만들어 관리하도록 하였습니다.

## 📑 상세 설명 
- 진단에 따른 병원 정보 제공 화면 구현중
- 네이버 지도 SDK 적용  
- .gitignore 적용

#12